### PR TITLE
deprecated devtools::use_testthat()

### DIFF
--- a/tests.rmd
+++ b/tests.rmd
@@ -56,7 +56,7 @@ If you're familiar with unit testing in other languages, you should note that th
 To set up your package to use testthat, run:
 
 ```{r, eval = FALSE}
-devtools::use_testthat()
+usethis::use_testthat()
 ```
 
 This will:


### PR DESCRIPTION
Message from R when running devtools::use_testthat()

Warning message:
'devtools::use_testthat' is deprecated.
Use 'usethis::use_testthat()' instead.
See help("Deprecated") and help("devtools-deprecated").